### PR TITLE
Feature/port selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+doc/*
+.js

--- a/samsung-tv-config-schema.coffee
+++ b/samsung-tv-config-schema.coffee
@@ -10,4 +10,8 @@ module.exports = {
     host:
       description: "IP address of the Samsung TV"
       type: "string"
+    port:
+      description: "The port to use"
+      type: "number"
+      default: 55000
 }


### PR DESCRIPTION
My Samsung TV uses another port than the default (7676 instead of 55000)

This pull request contains functionality to change that port in the configuration of the plugin and in the action rules.